### PR TITLE
Example shiny app as a sandbox

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,10 +1,11 @@
 Package: FacileIncubator
 Type: Package
 Title: Incubator for half-baked ideas
-Version: 0.0.8
+Version: 0.0.9
 Authors@R: c(
     person("Steve", "Lianoglou", , "lianoglou@dnli.com", c("aut", "cre"),
       comment = c(ORCID = "0000-0002-0924-1754")),
+      person("Jonathan", "Carroll", email = "rpkg@jcarroll.com.au", role = c("ctb"), comment = c(ORCID = "0000-0002-1404-5264")),
     person("Denali Therapeutics", role = c("cph", "fnd")))
 Description: This is a safe place to develop half-baked ideas that are surely
     destined for greatness someday.

--- a/inst/shiny/sandbox/server.R
+++ b/inst/shiny/sandbox/server.R
@@ -74,12 +74,13 @@ shinyServer(function(input, output, session) {
     if (debug) print(paste0("this module is ", module_id))
     module_stack(c(module_id, module_stack()))
     
-    ui.content <- analysisUI()(ifelse(isolate(req(input$analysis)) == "filter","ds","analysis"), debug = debug)
+    context_id <- ifelse(isolate(req(input$analysis)) == "filter", "rfds", "analysis")
+    ui.content <- analysisUI()(context_id, debug = debug)
     
     ui <- tagList(
       ui.content
     )
-    
+
     ui_with_id <- module_UI(module_id, ui)
     
     ## NOTE: immediate = TRUE is necessary!
@@ -118,22 +119,21 @@ shinyServer(function(input, output, session) {
     checkmate::assert_class(fds., "FacileDataStore")
     checkmate::assert_class(samples., "facile_frame")
 
-    FacileShine::ReactiveFacileDataStore(fds., "ds", samples = samples.)
+    FacileShine::ReactiveFacileDataStore(fds., "rfds", samples = samples., debug = debug)
   })
   
   module_res <- reactive({
-    res <- callModule(analysisModule(), 
-               id = ifelse(req(input$analysis) == "filter", "ds", "analysis"),
-               rfds = rfds(), 
-               aresult = x(), 
-               gdb = reactive({sparrow::exampleGeneSetDb()}), 
-               path= reactive(rfds()[["parent.dir"]]),
-               debug = debug
-    )
     if (req(input$analysis) == "filter") {
-      return(rfds())
+      rfds()
     } else {
-      return(res)
+      callModule(analysisModule(), 
+                 id = "analysis",
+                 rfds = rfds(), 
+                 aresult = x(), 
+                 gdb = reactive({sparrow::exampleGeneSetDb()}), 
+                 path= reactive(rfds()[["parent.dir"]]),
+                 debug = debug
+      )
     }
   })
   

--- a/inst/shiny/sandbox/server.R
+++ b/inst/shiny/sandbox/server.R
@@ -114,7 +114,13 @@ shinyServer(function(input, output, session) {
     
     .x <- x()
     fds. <- FacileData::fds(.x)
-    samples. <- dplyr::collect(FacileData::samples(.x), n = Inf)
+    
+    if (is(fds., "BoxedFacileDataStore")) {
+      samples. <- FacileShine::active_samples(.x)
+    } else {
+      samples. <- FacileData::samples(.x)
+    }
+    samples. <- dplyr::collect(samples., n= Inf)
     
     checkmate::assert_class(fds., "FacileDataStore")
     checkmate::assert_class(samples., "facile_frame")

--- a/inst/shiny/sandbox/server.R
+++ b/inst/shiny/sandbox/server.R
@@ -26,7 +26,13 @@ module_UI <- function(id, ui) {
 shinyServer(function(input, output, session) {
   
   module_stack <- reactiveVal(NULL)
-  results_stack <- reactiveVal(tibble::tibble(id = character(), analysis = character(), result = list()))
+  results_stack <- reactiveVal(
+    tibble::tibble(
+      id = character(), 
+      analysis = character(), 
+      result = list()
+    )
+  )
   
   observe({
     shinyjs::disable("remove_module")
@@ -129,12 +135,6 @@ shinyServer(function(input, output, session) {
   module_res <- reactive({
     if (req(input$analysis) == "filter") {
       rfds()
-      # callModule(analysisModule(), 
-      #            id = "analysis",
-      #            gdb = reactive({sparrow::exampleGeneSetDb()}), 
-      #            path= reactive(FacileData::fds(x())[["parent.dir"]]),
-      #            debug = debug
-      # )
     } else {
       callModule(analysisModule(), 
                  id = "analysis",
@@ -164,7 +164,11 @@ shinyServer(function(input, output, session) {
     results_stack(
       rbind(
         results_stack(), 
-        tibble::tibble(id = paste0("result_", input$add_module), analysis = input$analysis, result = list(res))
+        tibble::tibble(
+          id = paste0("result_", input$add_module), 
+          analysis = input$analysis, 
+          result = list(res)
+        )
       )
     )
     if (debug) {
@@ -172,7 +176,11 @@ shinyServer(function(input, output, session) {
       print(results_stack())
     }
     
-    shinyWidgets::updatePickerInput(session, "dataset", choices = c("TCGA", results_stack()$id), selected = input$dataset)
+    shinyWidgets::updatePickerInput(
+      session, "dataset", 
+      choices = c("TCGA", results_stack()$id), 
+      selected = input$dataset
+    )
   })
   
   output$results_list <- renderTable({

--- a/inst/shiny/sandbox/server.R
+++ b/inst/shiny/sandbox/server.R
@@ -112,13 +112,8 @@ shinyServer(function(input, output, session) {
     req(input$analysis != "none")
     
     .x <- x()
-    if (is(.x, "ReactiveFacileDataStore")) {
-      fds. <- .x$.state$fds
-      samples. <- .x$.state$active_samples
-    } else {
-      fds. <- FacileData::fds(.x)
-      samples. <- dplyr::collect(FacileData::samples(.x), n = Inf)
-    }
+    fds. <- FacileData::fds(.x)
+    samples. <- dplyr::collect(FacileData::samples(.x), n = Inf)
     
     checkmate::assert_class(fds., "FacileDataStore")
     checkmate::assert_class(samples., "facile_frame")

--- a/inst/shiny/sandbox/server.R
+++ b/inst/shiny/sandbox/server.R
@@ -26,6 +26,7 @@ module_UI <- function(id, ui) {
 shinyServer(function(input, output, session) {
   
   module_stack <- reactiveVal(NULL)
+  results_stack <- reactiveVal(data.frame(id = integer(), analysis = character()))
   
   observe({
     shinyjs::disable("remove_module")
@@ -134,6 +135,11 @@ shinyServer(function(input, output, session) {
     req(input$analysis != "none")
     if (debug) print("running analysis")
     analysis <- callModule(analysisModule(), "analysis", rfds(), debug = debug)
+    results_stack(rbind(results_stack(), data.frame(id = input$add_module, type = input$analysis)))
+  })
+  
+  output$results_list <- renderTable({
+    if (NROW(results_stack()) > 0) results_stack() else NULL
   })
   
 })

--- a/inst/shiny/sandbox/server.R
+++ b/inst/shiny/sandbox/server.R
@@ -1,0 +1,85 @@
+library(shiny)
+
+shinyServer(function(input, output, session) {
+  
+  debug <- FALSE
+  bs4dash <- getOption("facile.bs4dash")
+  options(facile.bs4dash = FALSE)
+  on.exit(options(facile.bs4dash = bs4dash))
+  
+  x <- reactive({
+    switch(req(input$dataset),
+           "TCGA" = FacileData:::exampleFacileDataSet(),
+           NULL
+    )
+  })
+  
+  analysisModule <- reactive({
+    switch(req(input$analysis),
+           "fdge" = FacileAnalysis::fdgeAnalysis,
+           "fpca" = FacileAnalysis::fpcaAnalysis,
+           "ffsea" = FacileAnalysis::ffseaAnalysis,
+           NULL
+    )
+  })
+
+  analysisUI <- reactive({
+    switch(req(input$analysis),
+           "fdge" = FacileAnalysis::fdgeAnalysisUI,
+           "fpca" = FacileAnalysis::fpcaAnalysisUI,
+           "ffsea" = FacileAnalysis::ffseaAnalysisUI,
+           NULL
+    )
+  })
+    
+  observeEvent(input$analysis, {
+    req(input$analysis != "none")
+    ui.content <- analysisUI()("analysis", debug = debug)
+    
+    ui <- tagList(
+      FacileShine::filteredReactiveFacileDataStoreUI("ds"),
+      tags$hr(),
+      ui.content
+    )
+    
+    ## NOTE: immediate = TRUE is necessary!
+    insertUI("#here", "afterEnd", ui, immediate = TRUE)
+  })
+  
+  ## this logic should be isolated into a function
+  rfds <- reactive({
+    req(input$analysis != "none")
+    
+    .x <- x()
+    if (is(.x, "facile_frame")) {
+      fds. <- FacileData::fds(.x)
+      samples. <- .x
+      sample.filter <- FALSE
+      restrict_samples <- samples.
+    } else if (is(.x, "FacileDataStore")) {
+      sample.filter <- TRUE
+      fds. <- .x
+      samples. <- dplyr::collect(FacileData::samples(.x), n = Inf)
+    } else if (is(.x, "FacileAnalysisResult")) {
+      # ugh, this isn't going to work -- I'm writing this in to fire up a
+      # ffseaGadget, whose needs to be a FacileAnalysisResult.
+      sample.filter <- FALSE
+      fds. <- FacileData::fds(.x)
+      samples. <- dplyr::collect(FacileData::samples(.x), n = Inf)
+      restrict_samples <- samples.
+    } else {
+      stop("What in the world?")
+    }
+    checkmate::assert_class(fds., "FacileDataStore")
+    checkmate::assert_class(samples., "facile_frame")
+    
+    FacileShine:::ReactiveFacileDataStore(fds., "ds", samples = samples.)
+  })
+  
+  observe({
+    req(input$analysis != "none")
+    analysis <- callModule(analysisModule(), "analysis", rfds(), debug = debug)
+  })
+  
+})
+

--- a/inst/shiny/sandbox/ui.R
+++ b/inst/shiny/sandbox/ui.R
@@ -1,0 +1,27 @@
+library(shiny)
+
+shinyUI(fluidPage(
+
+    # Application title
+    titlePanel("FacileSandbox"),
+
+    sidebarLayout(
+        sidebarPanel(width = 3,
+          
+          shinyWidgets::pickerInput("dataset",
+                                    "Select a dataset",
+                                    choices = "TCGA",
+                                    selected = "TCGA"
+          ),
+          shinyWidgets::pickerInput("analysis",
+                                    "Select an analysis:",
+                                    choices = c("none", "fdge", "fpca", "ffsea"),
+                                    selected = "none"
+          )
+        ),
+
+        mainPanel(
+            tags$div(id = "here")
+        )
+    )
+))

--- a/inst/shiny/sandbox/ui.R
+++ b/inst/shiny/sandbox/ui.R
@@ -19,7 +19,10 @@ shinyUI(fluidPage(
                                                selected = "none"
                      ),
                      actionButton("add_module", "Add", icon = icon("plus-circle")),
-                     actionButton("remove_module", "Remove", icon = icon("trash-alt"))
+                     actionButton("remove_module", "Remove", icon = icon("trash-alt")),
+                     br(),
+                     h4("Results:"),
+                     tableOutput("results_list")
         ),
         
         mainPanel(

--- a/inst/shiny/sandbox/ui.R
+++ b/inst/shiny/sandbox/ui.R
@@ -7,21 +7,23 @@ shinyUI(fluidPage(
 
     sidebarLayout(
         sidebarPanel(width = 3,
-          
-          shinyWidgets::pickerInput("dataset",
-                                    "Select a dataset",
-                                    choices = "TCGA",
-                                    selected = "TCGA"
-          ),
-          shinyWidgets::pickerInput("analysis",
-                                    "Select an analysis:",
-                                    choices = c("none", "fdge", "fpca", "ffsea"),
-                                    selected = "none"
-          )
+                     shinyjs::useShinyjs(),
+                     shinyWidgets::pickerInput("dataset",
+                                               "Select a dataset",
+                                               choices = "TCGA",
+                                               selected = "TCGA"
+                     ),
+                     shinyWidgets::pickerInput("analysis",
+                                               "Select an analysis:",
+                                               choices = c("none", "fdge", "fpca", "ffsea"),
+                                               selected = "none"
+                     ),
+                     actionButton("add_module", "Add", icon = icon("plus-circle")),
+                     actionButton("remove_module", "Remove", icon = icon("trash-alt"))
         ),
-
+        
         mainPanel(
-            tags$div(id = "here")
+          tags$div(id = "gadget_container")
         )
     )
 ))

--- a/inst/shiny/sandbox/ui.R
+++ b/inst/shiny/sandbox/ui.R
@@ -9,12 +9,12 @@ shinyUI(fluidPage(
         sidebarPanel(width = 3,
                      shinyjs::useShinyjs(),
                      shinyWidgets::pickerInput("dataset",
-                                               "Select a dataset",
+                                               "Select an input:",
                                                choices = "TCGA",
                                                selected = "TCGA"
                      ),
                      shinyWidgets::pickerInput("analysis",
-                                               "Select an analysis:",
+                                               "Select an output:",
                                                choices = c("none", "fdge", "fpca", "ffsea"),
                                                selected = "none"
                      ),

--- a/inst/shiny/sandbox/ui.R
+++ b/inst/shiny/sandbox/ui.R
@@ -10,16 +10,16 @@ shinyUI(fluidPage(
                      shinyjs::useShinyjs(),
                      shinyWidgets::pickerInput("dataset",
                                                "Select an input:",
-                                               choices = "TCGA",
+                                               choices = c("TCGA"),
                                                selected = "TCGA"
                      ),
                      shinyWidgets::pickerInput("analysis",
                                                "Select an output:",
-                                               choices = c("none", "fdge", "fpca", "ffsea"),
+                                               choices = c("none", "filter", "fdge", "fpca", "ffsea"),
                                                selected = "none"
                      ),
                      actionButton("add_module", "Add", icon = icon("plus-circle")),
-                     actionButton("remove_module", "Remove", icon = icon("trash-alt")),
+                     actionButton("remove_module", "Done", icon = icon("check-circle")),
                      br(),
                      h4("Results:"),
                      tableOutput("results_list")


### PR DESCRIPTION
This PR adds a shiny app in `inst/shiny/sandbox` which can load any of `fdge`, `fpca`, or `ffsea` as modules. 

This is a barebones app with no additional features, merely a prototype for a sandbox in which modules could be loaded. This helped identify some minor issues (e.g. https://github.com/facilebio/FacileAnalysis/pull/49 and something else happening with `ffsea` which crashes here). This also has some best-practices in terms of cleaning up destroyed modules. I've also used it to prototype the idea of keeping a running list of analyses performed - again, this is just a simple implementation.

Dataset loading is limited to `FacileData:::exampleFacileDataSet()`.